### PR TITLE
[Feature/ViewMode] : navigation backbutton 레이블 수정 및 에러 수정

### DIFF
--- a/Owori/Owori.xcodeproj/project.pbxproj
+++ b/Owori/Owori.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		F36A82952A71921A00C6A90C /* BackToFamilyLinkViewButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36A82942A71921A00C6A90C /* BackToFamilyLinkViewButton.swift */; };
 		F37CDD0F2A86578D0002FFFE /* AppleLoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37CDD0E2A86578D0002FFFE /* AppleLoginButton.swift */; };
 		F38C12932A83920500DDAAA8 /* ZoomDetailImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38C12922A83920500DDAAA8 /* ZoomDetailImageCell.swift */; };
+		F39B28492A8C02E3000D26C7 /* TestBackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39B28482A8C02E3000D26C7 /* TestBackButton.swift */; };
 		F39EF2822A6B93E5005FD6DB /* JoinNickname.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39EF2812A6B93E5005FD6DB /* JoinNickname.swift */; };
 		F39EF2842A6B95D3005FD6DB /* JoinBirthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39EF2832A6B95D3005FD6DB /* JoinBirthday.swift */; };
 		F39EF2862A6B96A1005FD6DB /* JoinFamilyName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39EF2852A6B96A1005FD6DB /* JoinFamilyName.swift */; };
@@ -230,6 +231,7 @@
 		F36A82942A71921A00C6A90C /* BackToFamilyLinkViewButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackToFamilyLinkViewButton.swift; sourceTree = "<group>"; };
 		F37CDD0E2A86578D0002FFFE /* AppleLoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginButton.swift; sourceTree = "<group>"; };
 		F38C12922A83920500DDAAA8 /* ZoomDetailImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomDetailImageCell.swift; sourceTree = "<group>"; };
+		F39B28482A8C02E3000D26C7 /* TestBackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestBackButton.swift; sourceTree = "<group>"; };
 		F39EF2812A6B93E5005FD6DB /* JoinNickname.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinNickname.swift; sourceTree = "<group>"; };
 		F39EF2832A6B95D3005FD6DB /* JoinBirthday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinBirthday.swift; sourceTree = "<group>"; };
 		F39EF2852A6B96A1005FD6DB /* JoinFamilyName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinFamilyName.swift; sourceTree = "<group>"; };
@@ -665,6 +667,7 @@
 				F3C1BE662A70F26E002ADB3B /* FamilyViewModelTestView.swift */,
 				F3C1BE682A70F2C6002ADB3B /* StoryViewModelTestView.swift */,
 				F3E8CDC92A810719007A0C3A /* ContentView.swift */,
+				F39B28482A8C02E3000D26C7 /* TestBackButton.swift */,
 			);
 			path = TestView;
 			sourceTree = "<group>";
@@ -900,6 +903,7 @@
 				35B3CD5A2A7D5CCF00127259 /* WriteDDay.swift in Sources */,
 				F3430FAC2A67043200DC1B1C /* User.swift in Sources */,
 				F3430FA32A67043200DC1B1C /* DailyStoryListCell.swift in Sources */,
+				F39B28492A8C02E3000D26C7 /* TestBackButton.swift in Sources */,
 				F3430F912A67043200DC1B1C /* LoginTestView.swift in Sources */,
 				356A54562A856001006E22C8 /* CalendarView.swift in Sources */,
 				F3430F9A2A67043200DC1B1C /* ContentText.swift in Sources */,

--- a/Owori/Owori/Extension/View+Extension.swift
+++ b/Owori/Owori/Extension/View+Extension.swift
@@ -11,13 +11,18 @@ extension View {
     func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
         clipShape( RoundedCorner(radius: radius, corners: corners) )
     }
+    
+    func endTextEditing() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
 }
 
-struct RoundedCorner: Shape {
 
+struct RoundedCorner: Shape {
+    
     var radius: CGFloat = .infinity
     var corners: UIRectCorner = .allCorners
-
+    
     func path(in rect: CGRect) -> Path {
         let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
         return Path(path.cgPath)

--- a/Owori/Owori/View/Home/DDay/WriteDDay.swift
+++ b/Owori/Owori/View/Home/DDay/WriteDDay.swift
@@ -156,12 +156,15 @@ struct WriteDDay: View {
             )
             Spacer()
         }
-        .navigationBarBackButtonHidden(true)
+        .onTapGesture {
+            self.endTextEditing()
+        }
+//        .navigationBarBackButtonHidden(true)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                BackCancel()
-            }
+//            ToolbarItem(placement: .navigationBarLeading) {
+//                BackCancel()
+//            }
             ToolbarItem(placement: .principal) {
                 
                 //MARK: HEADER 작성하기

--- a/Owori/Owori/View/Home/DDay/WriteDDay.swift
+++ b/Owori/Owori/View/Home/DDay/WriteDDay.swift
@@ -159,40 +159,33 @@ struct WriteDDay: View {
         .onTapGesture {
             self.endTextEditing()
         }
-//        .navigationBarBackButtonHidden(true)
+        //        .navigationBarBackButtonHidden(true)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-//            ToolbarItem(placement: .navigationBarLeading) {
-//                BackCancel()
-//            }
+            //            ToolbarItem(placement: .navigationBarLeading) {
+            //                BackCancel()
+            //            }
             ToolbarItem(placement: .principal) {
                 
                 //MARK: HEADER 작성하기
-                HStack(alignment: .center) {
-                    
-                    Spacer()
-                    
-                    Text("작성하기")
-                        .font(
-                            Font.custom("Pretendard", size: 20)
-                                .weight(.bold)
-                        )
-                        .foregroundColor(Color(red: 0.13, green: 0.13, blue: 0.13))
-                    
-                    Spacer()
-                    
-                    Button {
-                        //View가 업데이트 된 상황에서 홈으로 복귀
-                        isAddDdayViewActive = false
-                    } label: {
-                        Image("Check")
-                            .frame(width: 30, height: 30)
-                    }
-                }
                 
+                Text("작성하기")
+                    .font(
+                        Font.custom("Pretendard", size: 20)
+                            .weight(.bold)
+                    )
+                    .foregroundColor(Color(red: 0.13, green: 0.13, blue: 0.13))
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    //View가 업데이트 된 상황에서 홈으로 복귀
+                    isAddDdayViewActive = false
+                } label: {
+                    Image("Check")
+                        .frame(width: 30, height: 30)
+                }
             }
         }
-        
     }
 }
 

--- a/Owori/Owori/View/Home/Family/AddFamilyPhoto.swift
+++ b/Owori/Owori/View/Home/Family/AddFamilyPhoto.swift
@@ -103,12 +103,15 @@ struct AddFamilyPhoto: View {
                 }.disabled(photoisOn.description.isEmpty || photoDescription.isEmpty)
             }
         }
-        .navigationBarBackButtonHidden(true)
+        .onTapGesture {
+            self.endTextEditing()
+        }
+//        .navigationBarBackButtonHidden(true)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                BackButton()
-            }
+//            ToolbarItem(placement: .navigationBarLeading) {
+//                BackButton()
+//            }
             ToolbarItem(placement: .principal) {
                 Text("사진 올리기")
                     .font(

--- a/Owori/Owori/View/Home/HomeHeaderButton/HomeNotificationView.swift
+++ b/Owori/Owori/View/Home/HomeHeaderButton/HomeNotificationView.swift
@@ -56,12 +56,12 @@ struct HomeNotificationView: View {
             
         }
         .padding(EdgeInsets(top: 30, leading: 20, bottom: 0, trailing: 20))
-        .navigationBarBackButtonHidden(true)
+//        .navigationBarBackButtonHidden(true)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                BackButton()
-            }
+//            ToolbarItem(placement: .navigationBarLeading) {
+//                BackButton()
+//            }
             ToolbarItem(placement: .principal) {
                 Text("알림")
                     .font(

--- a/Owori/Owori/View/Home/HomeHelper/BackButton.swift
+++ b/Owori/Owori/View/Home/HomeHelper/BackButton.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct BackButton: View {
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    @GestureState private var dragOffset = CGSize.zero
     
     var body: some View {
         Button {
@@ -18,6 +19,13 @@ struct BackButton: View {
                 .aspectRatio(contentMode: .fit)
                 .foregroundColor(.black)
         }
+        .gesture(DragGesture().updating($dragOffset, body: { (value, state, transaction) in
+                
+                    if(value.startLocation.x < 20 && value.translation.width > 100) {
+                        self.presentationMode.wrappedValue.dismiss()
+                    }
+                    
+                }))
     }
 }
 

--- a/Owori/Owori/View/Home/Report/ReportView.swift
+++ b/Owori/Owori/View/Home/Report/ReportView.swift
@@ -36,7 +36,7 @@ struct ReportView: View {
     
     var body: some View {
         
-        VStack{
+        ScrollView{
             
             VStack(alignment: .leading){
                 
@@ -214,18 +214,21 @@ struct ReportView: View {
             .offset(y: UIScreen.main.bounds.height * 0.1)
             .disabled(!isButtonEnabled)
         }
-        .navigationBarBackButtonHidden(true)
+//        .navigationBarBackButtonHidden(true)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                BackButton()
-            }
+//            ToolbarItem(placement: .navigationBarLeading) {
+//                BackButton()
+//            }
             ToolbarItem(placement: .principal) {
                 Text("신고하기")
                     .font(.title3)
                     .bold()
                     .foregroundColor(Color.black)
             }
+        }
+        .onTapGesture {
+            self.endTextEditing()
         }
         
     }

--- a/Owori/Owori/View/Login/JoinView/BeInviteFamily.swift
+++ b/Owori/Owori/View/Login/JoinView/BeInviteFamily.swift
@@ -78,6 +78,9 @@ struct BeInviteFamily: View {
                 
             }
         }
+        .onTapGesture {
+            self.endTextEditing()
+        }
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .toolbar {

--- a/Owori/Owori/View/Login/JoinView/JoinBirthday.swift
+++ b/Owori/Owori/View/Login/JoinView/JoinBirthday.swift
@@ -83,6 +83,9 @@ struct JoinBirthday: View {
                 currentIndex = 2
             }
         }
+        .onTapGesture {
+            self.endTextEditing()
+        }
         .navigationBarTitleDisplayMode(.inline)
         .navigationDestination(isPresented: $isThirdViewActive) {
             JoinFamilyName(isLoggedIn: $isLoggedIn, currentIndex: $currentIndex, nickname: $nickname, birthDateText: $birthDateText, familyName: $familyName, inviteCode: $inviteCode)

--- a/Owori/Owori/View/Login/JoinView/JoinFamilyName.swift
+++ b/Owori/Owori/View/Login/JoinView/JoinFamilyName.swift
@@ -85,6 +85,9 @@ struct JoinFamilyName: View {
                 currentIndex = 3
             }
         }
+        .onTapGesture {
+            self.endTextEditing()
+        }
         .navigationBarTitleDisplayMode(.inline)
         .navigationDestination(isPresented: $isFourthViewActive) {
             JoinFamily(isLoggedIn: $isLoggedIn, currentIndex: $currentIndex, nickname: $nickname, birthDateText: $birthDateText, familyName: $familyName, inviteCode: $inviteCode)

--- a/Owori/Owori/View/Login/JoinView/JoinNickname.swift
+++ b/Owori/Owori/View/Login/JoinView/JoinNickname.swift
@@ -77,6 +77,9 @@ struct JoinNickname: View {
                 currentIndex = 1
             }
         }
+        .onTapGesture {
+            self.endTextEditing()
+        }
         .navigationBarTitleDisplayMode(.inline)
         .navigationDestination(isPresented: $isSecondViewActive) {
             JoinBirthday(isLoggedIn: $isLoggedIn, currentIndex: $currentIndex, nickname: $nickname, birthDateText: $birthDateText, familyName: $familyName, inviteCode: $inviteCode)

--- a/Owori/Owori/View/MainView.swift
+++ b/Owori/Owori/View/MainView.swift
@@ -52,6 +52,8 @@ struct MainView: View {
                     }
                     .tag(2)
             }
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
             .onAppear {
                 familyViewModel.lookUpHomeView(user: userViewModel.user) {
                     print(familyViewModel.getFamily())

--- a/Owori/Owori/View/MyPage/MyPageInfo/EditMyPage.swift
+++ b/Owori/Owori/View/MyPage/MyPageInfo/EditMyPage.swift
@@ -144,6 +144,9 @@ struct EditMyPage: View {
             Spacer()
             
         }
+        .onTapGesture {
+            self.endTextEditing()
+        }
         //        .navigationBarBackButtonHidden(true)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/Owori/Owori/View/MyPage/MyPageInfo/MyPageProfile.swift
+++ b/Owori/Owori/View/MyPage/MyPageInfo/MyPageProfile.swift
@@ -55,13 +55,9 @@ struct MyPageProfile: View {
 //                    SettingView()
 //                }
         .toolbar {
-//            ToolbarItem(placement: .navigationBarLeading) {
-//                BackButton()
-//            }
             ToolbarItem(placement: .navigationBarTrailing) {
                 
                 HStack{
-                    
                     NavigationLink {
                         //edit 버튼 누르면 작동
 //                        editMyPageIsActive = true

--- a/Owori/Owori/View/MyPage/Setting/Attribute/FamilyNameChangeView.swift
+++ b/Owori/Owori/View/MyPage/Setting/Attribute/FamilyNameChangeView.swift
@@ -68,14 +68,17 @@ struct FamilyNameChangeView: View {
             }
             
         }
-        .navigationBarBackButtonHidden(true)
+        .onTapGesture {
+            self.endTextEditing()
+        }
+//        .navigationBarBackButtonHidden(true)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 
                 HStack(alignment: .center) {
                     
-                    BackButton()
+//                    BackButton()
                     
                     Spacer()
                     

--- a/Owori/Owori/View/MyPage/Setting/Attribute/InviteView.swift
+++ b/Owori/Owori/View/MyPage/Setting/Attribute/InviteView.swift
@@ -87,13 +87,13 @@ struct InviteView: View {
 
             Spacer()
         }
-        .navigationBarBackButtonHidden(true)
+//        .navigationBarBackButtonHidden(true)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                    BackButton()
-            }
-        }
+//        .toolbar {
+//            ToolbarItem(placement: .navigationBarLeading) {
+//                    BackButton()
+//            }
+//        }
     }
 }
 

--- a/Owori/Owori/View/MyPage/Setting/SettingView.swift
+++ b/Owori/Owori/View/MyPage/Setting/SettingView.swift
@@ -342,12 +342,13 @@ struct SettingView: View {
 //                BackButton()
 //            }
             ToolbarItem(placement: .principal) {
-                Text("설정")
-                    .font(.title3)
-                    .bold()
-                    .foregroundColor(Color.black)
+                    Text("설정")
+                        .font(.title3)
+                        .bold()
+                        .foregroundColor(Color.black)
             }
-        }.background(Color.oworiMain)
+        }
+        .background(Color.oworiMain)
             .navigationDestination(isPresented: $FamilyNameChangeViewIsActive) {
                         FamilyNameChangeView()
                     }

--- a/Owori/Owori/View/Story/Detail/ZoomImages.swift
+++ b/Owori/Owori/View/Story/Detail/ZoomImages.swift
@@ -37,16 +37,16 @@ struct ZoomImages: View {
             
         }
         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-        .navigationBarBackButtonHidden(true)
+//        .navigationBarBackButtonHidden(true)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    
-                } label: {
-                    BackButton()
-                }
-            }
+//            ToolbarItem(placement: .navigationBarLeading) {
+//                Button {
+//
+//                } label: {
+//                    BackButton()
+//                }
+//            }
             
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {

--- a/Owori/Owori/View/Story/Record/RecordSuccessButton.swift
+++ b/Owori/Owori/View/Story/Record/RecordSuccessButton.swift
@@ -48,7 +48,6 @@ struct RecordSuccessButton: View {
                             stories = storyViewModel.getStories()
                             print("[getStoryTest]\(stories)")
                             print("[getStoriesForcollection] : \(storyViewModel.getStoriesForCollection())")
-                            self.presentationMode.wrappedValue.dismiss()
                         }
                         
                     }
@@ -60,11 +59,7 @@ struct RecordSuccessButton: View {
                     
                 }
             }
-            
-            
-            
-            
-            
+            self.presentationMode.wrappedValue.dismiss()
             
         } label: {
             Text("작성 완료")

--- a/Owori/Owori/View/Story/Record/RecordSuccessButton.swift
+++ b/Owori/Owori/View/Story/Record/RecordSuccessButton.swift
@@ -46,7 +46,7 @@ struct RecordSuccessButton: View {
                         storyViewModel.lookUpStorySortByStartDate(user: userViewModel.user) {
                             
                             stories = storyViewModel.getStories()
-                            print("[getStoryTest]\(stories)")
+                            print("[getStoryTest Record]\(stories)")
                             print("[getStoriesForcollection] : \(storyViewModel.getStoriesForCollection())")
                         }
                         

--- a/Owori/Owori/View/Story/Record/StoryRecordView.swift
+++ b/Owori/Owori/View/Story/Record/StoryRecordView.swift
@@ -199,10 +199,12 @@ struct StoryRecordView: View {
             RecordSuccessButton(startDate: $startDate, endDate: $endDate, title: $title, content: $content, storyImages: $storyImages, selectedImages: $selectedImages, stories: $stories)
             
         }
+        .onTapGesture {
+            self.endTextEditing()
+        }
         .padding(EdgeInsets(top: 0, leading: 15, bottom: 0, trailing: 15))
         .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden(true)
-        .navigationBarItems(leading: BackButton())
+//        .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 Text("기록하기")

--- a/Owori/Owori/View/Story/Search/StorySearchView.swift
+++ b/Owori/Owori/View/Story/Search/StorySearchView.swift
@@ -15,25 +15,9 @@ struct StorySearchView: View {
     @State private var isExistSearchResult: Bool = false
     var body: some View {
         VStack {
-            HStack {
-                CustomNavigationBackButton()
-                HStack {
-                    TextField("추억을 검색해보세요", text: $searchText)
-                    Button {
-                        searchText = ""
-                    } label: {
-                        if searchText.isEmpty {
-                            EmptyView()
-                        } else {
-                            Image("Close")
-                        }
-                    }
-                }
-                .padding(EdgeInsets(top: 12, leading: 12, bottom: 10, trailing: 12))
-                .background(Color.oworiGray100)
-                .cornerRadius(10)
-                .frame(height: 60)
-            }
+//            HStack {
+//                CustomNavigationBackButton()
+//            }
             HStack {
                 Text("최근 검색어")
                     .font(.title3)
@@ -43,7 +27,7 @@ struct StorySearchView: View {
                 Text("전체 삭제")
                     .foregroundColor(Color.oworiGray400)
             }
-            .padding(EdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0))
+            .padding(EdgeInsets(top: 20, leading: 0, bottom: 10, trailing: 0))
             Spacer()
             
             if searchText.isEmpty {
@@ -84,7 +68,29 @@ struct StorySearchView: View {
             
             Spacer()
         }
+        .onTapGesture {
+            self.endTextEditing()
+        }
         .padding(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                HStack {
+                    TextField("추억을 검색해보세요", text: $searchText)
+                    Button {
+                        searchText = ""
+                    } label: {
+                        if searchText.isEmpty {
+                            EmptyView()
+                        } else {
+                            Image("Close")
+                        }
+                    }
+                }
+                .padding(EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20))
+                .background(Color.oworiGray100)
+                .cornerRadius(10)
+            }
+        }
     }
 }
 

--- a/Owori/Owori/View/Story/StoryHelper/StoryViewHeader.swift
+++ b/Owori/Owori/View/Story/StoryHelper/StoryViewHeader.swift
@@ -29,7 +29,6 @@ struct StoryViewHeader: View {
         .background(Color.oworiMain)
         .navigationDestination(isPresented: $isSearchViewVisible) {
             StorySearchView()
-                .navigationBarBackButtonHidden(true)
         }
         
     }

--- a/Owori/Owori/View/Story/StoryView.swift
+++ b/Owori/Owori/View/Story/StoryView.swift
@@ -16,6 +16,7 @@ struct StoryView: View {
     @EnvironmentObject var storyViewModel: StoryViewModel
     
     @State private var stories: [Story.StoryInfo] = []
+    @State private var albumListTab = 0
     
     // MARK: BODY
     var body: some View {
@@ -29,32 +30,30 @@ struct StoryView: View {
                 }
                 .padding(EdgeInsets(top: 20, leading: 20, bottom: 20, trailing: 20))
                 ScrollView {
-                    if buttonSet {
+//                    if buttonSet {
                         StoryListView(stories: $stories)
                             .onAppear {
                                 storyViewModel.lookUpStorySortByStartDate(user: userViewModel.user) {
                                     stories = storyViewModel.getStories()
-                                    print("[getStoryTest]\(stories)")
-                                    print("[getStoriesForcollection] : \(storyViewModel.getStoriesForCollection())")
+                                    print("[getStoryTest List]\(stories)")
                                 }
                             }
-                    } else {
+//                    } else {
                         StoryAlbumView(stories: $stories)
                             .onAppear {
                                 storyViewModel.lookUpStorySortByStartDate(user: userViewModel.user) {
                                     stories = storyViewModel.getStories()
-                                    print("[getStoryTest]\(stories)")
-                                    print("[getStoriesForcollection] : \(storyViewModel.getStoriesForCollection())")
+                                    print("[getStoryTest Album]\(stories)")
+                                    print("[getStoryTest Album] : \(storyViewModel.getStoriesForCollection())")
                                 }
                             }
-                    }
+//                    }
                 }
             }
             RecordButton(stories: $stories)
                 // 임시로 설정
                 .padding(.bottom, 30)
         }
-        
     }
 }
 

--- a/Owori/Owori/View/TestView/TestBackButton.swift
+++ b/Owori/Owori/View/TestView/TestBackButton.swift
@@ -1,0 +1,29 @@
+//
+//  TestBackButton.swift
+//  Owori
+//
+//  Created by Kyungsoo Lee on 2023/08/16.
+//
+
+import SwiftUI
+
+struct TestBackButton: View {
+    var label: String
+        
+        var body: some View {
+            Button(action: {
+                // Handle back button action if needed
+            }) {
+                HStack {
+                    Image(systemName: "arrow.left.circle.fill")
+                    Text(label)
+                }
+            }
+        }
+}
+
+struct TestBackButton_Previews: PreviewProvider {
+    static var previews: some View {
+        TestBackButton(label: "arrow.left.circle.fill")
+    }
+}


### PR DESCRIPTION
# View
1. WriteDDay
2. AddFamilyPhoto
3. HomeNOtificationView
4. BackButton
5. ReportView
6. BeInviteFamily
7. JoinBirthday
8. JoinFamilyName
9. JoinNickname
10. MainView
11. EditMyPage
12. MyPageProfile
13. FamilyNameChangeView
14. InviteView
15. SettingView
16. ZoomImages
17. RecordSuccessButton
18. StoryRecordView
19. StorySearchView
20. StoryViewHeader
21. StoryView
22. TestBackButton


# Model
- 

# ViewModel
- 

# 기타
1. View+Extension

# 구현 영상 & 사진
- 

# 이슈
1. 생일 입력시 제대로 입력되지 않으면 해당 페이지 자체를 못넘어가게 해야될 것 같음.
2. StoryView -> storyDetailView -> searchView -> storyDetailView -> 뒤로가기(2번) 을 누르면 로그인화면으로 돌아가는데, 아마 searchView에서 뒤로가는 과정에서 두 번째는 mainView로 넘어가는 과정이 표시가 안되고 버튼만 작동해서 loginView로 넘어가는듯... 
