### PR TITLE
[feature/Viewfix] ModfyStartDateandEndDateView

### DIFF
--- a/Owori/Owori/View/Home/DDay/WriteDDay.swift
+++ b/Owori/Owori/View/Home/DDay/WriteDDay.swift
@@ -105,6 +105,7 @@ struct WriteDDay: View {
                         selection: $date,
                         displayedComponents: [.date]
                     ).frame(width: UIScreen.main.bounds.width*0.4)
+                        .padding(EdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 0))
                     
                     
                     DatePicker(
@@ -112,6 +113,7 @@ struct WriteDDay: View {
                         selection: $date1,
                         displayedComponents: [.date]
                     ).frame(width: UIScreen.main.bounds.width*0.4)
+                        .padding(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 10))
                     
                 }
                 

--- a/Owori/Owori/View/Home/DDay/WriteDDay.swift
+++ b/Owori/Owori/View/Home/DDay/WriteDDay.swift
@@ -104,18 +104,19 @@ struct WriteDDay: View {
                         "시작일",
                         selection: $date,
                         displayedComponents: [.date]
-                    ).frame(width: UIScreen.main.bounds.width*0.4)
-                        .padding(EdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 0))
-                    
+                    )
+                    .kerning(-2)
+                    .frame(width: UIScreen.main.bounds.width*0.4)
                     
                     DatePicker(
                         "종료일",
                         selection: $date1,
                         displayedComponents: [.date]
-                    ).frame(width: UIScreen.main.bounds.width*0.4)
-                        .padding(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 10))
+                    )
+                    .kerning(-2)
+                    .frame(width: UIScreen.main.bounds.width*0.4)
                     
-                }
+                }.frame(width: UIScreen.main.bounds.width*0.9)
                 
                 //DDay - Switch Button
                 HStack(alignment: .top,spacing: 16) {

--- a/Owori/Owori/View/Story/Record/StoryRecordView.swift
+++ b/Owori/Owori/View/Story/Record/StoryRecordView.swift
@@ -54,23 +54,28 @@ struct StoryRecordView: View {
                                 selection: $startDate,
                                 displayedComponents: [.date]
                             )
+                            .kerning(0)
+                            .padding(.leading,15)
+                            
                         }
-                        .padding(.trailing,5)
-                        .frame(width: UIScreen.main.bounds.width * 0.4)
+                        .frame(width: UIScreen.main.bounds.width * 0.5)
+                        .padding(.leading,10)
                         
 //                        Spacer()
-                        
+//
                         HStack {
                             DatePicker(
                                 "종료일",
                                 selection: $endDate,
                                 displayedComponents: [.date]
                             )
+                            .kerning(0)
+                            .padding(.trailing,15)
                         }
-                        .padding(.leading,5)
-                        .frame(width: UIScreen.main.bounds.width * 0.4)
+                        .frame(width: UIScreen.main.bounds.width * 0.5)
+                        .padding(.trailing,10)
                     }
-                    .frame(width: UIScreen.main.bounds.width*0.95)
+                    .frame(width: UIScreen.main.bounds.width)
                     .padding(.top, 15)
                     .padding(.bottom, 30)
                 
@@ -181,6 +186,7 @@ struct StoryRecordView: View {
                     }
                 }
             }
+            .padding(EdgeInsets(top: 0, leading: 15, bottom: 0, trailing: 15))
             
             Button {
                 

--- a/Owori/Owori/View/Story/Record/StoryRecordView.swift
+++ b/Owori/Owori/View/Story/Record/StoryRecordView.swift
@@ -46,10 +46,7 @@ struct StoryRecordView: View {
     var body: some View {
         
         ScrollView {
-            
             VStack{
-                //DatePicker
-                ScrollView(.horizontal) {
                     HStack {
                         HStack {
                             DatePicker(
@@ -58,10 +55,10 @@ struct StoryRecordView: View {
                                 displayedComponents: [.date]
                             )
                         }
-                        .padding(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -30))
+                        .padding(.trailing,5)
                         .frame(width: UIScreen.main.bounds.width * 0.4)
                         
-                        Spacer()
+//                        Spacer()
                         
                         HStack {
                             DatePicker(
@@ -70,13 +67,12 @@ struct StoryRecordView: View {
                                 displayedComponents: [.date]
                             )
                         }
-                        .padding(EdgeInsets(top: 0, leading: -30, bottom: 0, trailing: 0))
+                        .padding(.leading,5)
                         .frame(width: UIScreen.main.bounds.width * 0.4)
                     }
-                    .frame(width: UIScreen.main.bounds.width)
+                    .frame(width: UIScreen.main.bounds.width*0.95)
+                    .padding(.top, 15)
                     .padding(.bottom, 30)
-                }
-                .kerning(0)
                 
                 if isDatePickerActive && isDateOutOfRange {
                     Text("시작일은 이전 날짜만 선택 가능해요")


### PR DESCRIPTION
View
1.WriteDDay
2.StoryRecordView

Model
-

ViewModel
-

기타


구현 영상 & 사진

iPhoneSE
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-08-20 at 04 10 00](https://github.com/TeamOwori/Owori-iOS/assets/102504021/06634aa3-a266-4f56-bf11-e11bd5863e7b)
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-08-20 at 04 10 06](https://github.com/TeamOwori/Owori-iOS/assets/102504021/81712e39-2206-43f2-9457-e75df87cbbfa)

iPhone14Plus
![Simulator Screenshot - iPhone 14 Plus - 2023-08-20 at 04 10 53](https://github.com/TeamOwori/Owori-iOS/assets/102504021/c6366edb-f568-4c07-beb5-0536af218568)
![Simulator Screenshot - iPhone 14 Plus - 2023-08-20 at 04 10 48](https://github.com/TeamOwori/Owori-iOS/assets/102504021/1f06bb52-0d86-4762-94af-59af1d90e959)

iPhone13mini
![IMG_3116](https://github.com/TeamOwori/Owori-iOS/assets/102504021/27c90811-f26f-43b6-8329-5082943ac973)
![IMG_3117](https://github.com/TeamOwori/Owori-iOS/assets/102504021/73a8ae74-511d-4db4-8f47-b42ff3159cb0)

iPad Air
![Simulator Screenshot - iPad Air (5th generation) - 2023-08-20 at 04 11 25](https://github.com/TeamOwori/Owori-iOS/assets/102504021/9defe04b-27a4-4547-82be-034f45e36983)
![Simulator Screenshot - iPad Air (5th generation) - 2023-08-20 at 04 11 36](https://github.com/TeamOwori/Owori-iOS/assets/102504021/a3ac6883-7e5a-4908-b6cc-6e339d27f6db)

해결완료
-시작일과 종료일 글자 깨짐 현상 수정 완료
-iPhone13mini에서 스토리 작성하는 뷰 테스트 했을 때의 뷰 간격이 일정하지 않아서 세로 padding 값 수정